### PR TITLE
Fix error when poi has no image

### DIFF
--- a/src/components/MapPOIInfo/index.js
+++ b/src/components/MapPOIInfo/index.js
@@ -32,7 +32,7 @@ const MapPOIInfo = props => {
             <Col>
               <Slider {...carouselSettings}>
                 {poi.imageList.length === 0
-                  ? "There is no images for this point at the moment."
+                  ? <div>There is no images for this point at the moment.</div>
                   : poi.imageList.map(image => (
                       <img
                         src={image}


### PR DESCRIPTION
Replicate:
1. Make a poi with no image
2. Select poi in map front and error will appear in the console