### PR TITLE
Add reset file input after upload

### DIFF
--- a/src/components/POIEditForm/index.js
+++ b/src/components/POIEditForm/index.js
@@ -287,6 +287,8 @@ class POIEditForm extends Component {
 
               // Resets the file states
               this.setState({ fileupload: null, uploadProgress: 0, showProgressBar: false });
+              var file = document.getElementById("fileupload");
+              file.value = file.defaultValue;
             },
               error => {
                 console.log(error);


### PR DESCRIPTION
Fixes bug where you can't upload a file directly after uploading the same file.
The fix resets the file to its default state after uploading a file.