### PR TITLE
Map front/feat/img name desc

### DIFF
--- a/src/components/MapPOIInfo/index.js
+++ b/src/components/MapPOIInfo/index.js
@@ -19,10 +19,6 @@ const carouselSettings = {
   speed: 1000
 };
 
-const getMeta = id => {};
-
-const getAllMeta = () => {};
-
 const ImageMeta = props => {
   const { name, desc } = props;
 
@@ -116,6 +112,9 @@ const style = (
     }
     .modal-dialog-scrollable .modal-content {
       max-height: 100vh;
+    }
+    .imageMetaContainer {
+      padding: 0.4rem 0 !important;
     }
   }
   ::-webkit-scrollbar {

--- a/src/components/MapPOIInfo/index.js
+++ b/src/components/MapPOIInfo/index.js
@@ -38,6 +38,12 @@ const getImageMeta = (imageMetaId, fileList) => {
   });
 };
 
+const getAudioMeta = (audioMetaId, fileList) => {
+  return fileList.find(e => {
+    return e._id === audioMetaId;
+  });
+};
+
 const MapPOIInfo = props => {
   const { poi, files, modal, toggle } = props;
 
@@ -81,14 +87,23 @@ const MapPOIInfo = props => {
 
               {poi.audioArray.length === 0
                 ? "There is no audio files for this point at the moment."
-                : poi.audioArray.map(audio => (
-                    <ReactAudioPlayer
-                      className="audioplayer"
-                      src={audio.url}
-                      key={audio.url.split("token=")[1]}
-                      controls
-                    />
-                  ))}
+                : poi.audioArray.map(audio => {
+                    const audioMeta = getAudioMeta(audio.metaID, files);
+
+                    return (
+                      <>
+                        <p style={{ marginBottom: ".5rem" }}>
+                          {audioMeta.name}
+                        </p>
+                        <ReactAudioPlayer
+                          className="audioplayer"
+                          src={audioMeta.url}
+                          key={audioMeta.url.split("token=")[1]}
+                          controls
+                        />
+                      </>
+                    );
+                  })}
             </Col>
           </Row>
           <hr style={{ marginTop: "0.5rem" }} />

--- a/src/components/MapPOIInfo/index.js
+++ b/src/components/MapPOIInfo/index.js
@@ -10,7 +10,7 @@ import ReactAudioPlayer from "react-audio-player";
 const carouselSettings = {
   accessibility: true,
   arrows: false,
-  autoplay: true,
+  // autoplay: true,
   autoplaySpeed: 3000,
   dots: true,
   infinite: true,
@@ -32,8 +32,14 @@ const ImageMeta = props => {
   );
 };
 
+const getImageMeta = (imageMetaId, fileList) => {
+  return fileList.find(e => {
+    return e._id === imageMetaId;
+  });
+};
+
 const MapPOIInfo = props => {
-  const { poi, modal, toggle } = props;
+  const { poi, files, modal, toggle } = props;
 
   return (
     <>
@@ -47,17 +53,23 @@ const MapPOIInfo = props => {
                 {poi.imageArray.length === 0 ? (
                   <div>There is no images for this point at the moment.</div>
                 ) : (
-                  poi.imageArray.map(image => (
-                    <>
-                      <img
-                        src={image.url}
-                        key={image.url.split("token=")[1]}
-                        alt="UWA History"
-                        className="carouselImage"
-                      />
-                      <ImageMeta name={image.name} />
-                    </>
-                  ))
+                  poi.imageArray.map(image => {
+                    const imageMeta = getImageMeta(image.metaID, files);
+
+                    return (
+                      <>
+                        <div className="imageContainer">
+                          <img
+                            src={imageMeta.url}
+                            key={imageMeta.url.split("token=")[1]}
+                            alt="UWA History"
+                            className="carouselImage"
+                          />
+                        </div>
+                        <ImageMeta name={imageMeta.name} />
+                      </>
+                    );
+                  })
                 )}
               </Slider>
             </Col>
@@ -115,6 +127,7 @@ const style = (
     }
     .imageMetaContainer {
       padding: 0.4rem 0 !important;
+      // height: auto;
     }
   }
   ::-webkit-scrollbar {
@@ -125,6 +138,7 @@ const style = (
     max-width: 100% !important;
     margin-left: auto !important;
     margin-right: auto !important;  
+    // margin: auto !important;
     width: auto !important;
     display: flex !important;
   }
@@ -135,21 +149,28 @@ const style = (
   .carouselRow {
     background-color: #fafafa;
   }
+  .imageContainer {
+    // display: flex;
+    // height: 400px;
+  }
   .imageMetaContainer {
     background-color: #fafafa;
     text-align: center;
     padding: .5rem 2rem;
+    bottom: 0;
   }
   .imageMetaBackground { 
     background-color: #eaeaea;
     height: 100%;
+    padding: .5rem;
   }
   .imageName {
     margin: 0;
   }
   .imageDesc {
-    margin-top: 10px;
+    margin: 10px 0 0 0;
     color: #000000ad;
+
   }
   .audioplayer {
     display: block;

--- a/src/components/MapPOIInfo/index.js
+++ b/src/components/MapPOIInfo/index.js
@@ -19,6 +19,23 @@ const carouselSettings = {
   speed: 1000
 };
 
+const getMeta = id => {};
+
+const getAllMeta = () => {};
+
+const ImageMeta = props => {
+  const { name, desc } = props;
+
+  return (
+    <div className="imageMetaContainer">
+      <div className="imageMetaBackground">
+        <p className="imageName">{name ? name : "No name"}</p>
+        <p className="imageDesc">{desc ? desc : "No description"}</p>
+      </div>
+    </div>
+  );
+};
+
 const MapPOIInfo = props => {
   const { poi, modal, toggle } = props;
 
@@ -35,11 +52,15 @@ const MapPOIInfo = props => {
                   <div>There is no images for this point at the moment.</div>
                 ) : (
                   poi.imageArray.map(image => (
-                    <img
-                      src={image.url}
-                      key={image.url.split("token=")[1]}
-                      alt="UWA History"
-                    />
+                    <>
+                      <img
+                        src={image.url}
+                        key={image.url.split("token=")[1]}
+                        alt="UWA History"
+                        className="carouselImage"
+                      />
+                      <ImageMeta name={image.name} />
+                    </>
                   ))
                 )}
               </Slider>
@@ -96,13 +117,9 @@ const style = (
     .modal-dialog-scrollable .modal-content {
       max-height: 100vh;
     }
-    
   }
   ::-webkit-scrollbar {
     width: 0px;
-  }
-  .slick-slide {
-    max-height: 400px;
   }
   .slick-slide img {
     max-height: 400px;
@@ -119,19 +136,27 @@ const style = (
   .carouselRow {
     background-color: #fafafa;
   }
-  // .carouselImage {
-  //   max-width: 100%;
-  //   max-height: 350x;
-  //   margin-left: auto;
-  //   margin-right: auto;
-  //   vertical-align: middle
-  // }
+  .imageMetaContainer {
+    background-color: #fafafa;
+    text-align: center;
+    padding: .5rem 2rem;
+  }
+  .imageMetaBackground { 
+    background-color: #eaeaea;
+    height: 100%;
+  }
+  .imageName {
+    margin: 0;
+  }
+  .imageDesc {
+    margin-top: 10px;
+    color: #000000ad;
+  }
   .audioplayer {
     display: block;
     width: 100%;
     margin-bottom: 0.5rem;
   }
-  
   `}</style>
 );
 

--- a/src/components/MapPOIInfo/index.js
+++ b/src/components/MapPOIInfo/index.js
@@ -72,7 +72,10 @@ const MapPOIInfo = props => {
                             className="carouselImage"
                           />
                         </div>
-                        <ImageMeta name={imageMeta.name} />
+                        <ImageMeta
+                          name={imageMeta.name}
+                          desc={imageMeta.description}
+                        />
                       </>
                     );
                   })

--- a/src/components/MapPage/index.js
+++ b/src/components/MapPage/index.js
@@ -19,6 +19,7 @@ class MapPage extends Component {
         lng: 0
       },
       POIList: [],
+      fileList: [],
       mapCenter: {
         lat: parseFloat(process.env.REACT_APP_UWA_LAT),
         lng: parseFloat(process.env.REACT_APP_UWA_LNG)
@@ -46,6 +47,26 @@ class MapPage extends Component {
         this.setState({
           POIList,
           loading: false
+        });
+      },
+      error => {
+        // TODO: set error state and display error as alert
+      }
+    );
+
+    this.filelistener = this.props.firebase.files().onSnapshot(
+      snapshot => {
+        let fileList = [];
+
+        snapshot.forEach(doc => {
+          const _id = doc.id;
+          const data = doc.data();
+          const file = { _id, ...data };
+          fileList.push(file);
+        });
+
+        this.setState({
+          fileList
         });
       },
       error => {
@@ -101,6 +122,7 @@ class MapPage extends Component {
 
   componentWillUnmount() {
     this.listener();
+    this.filelistener();
   }
 
   delayedShowMarker = () => {
@@ -143,7 +165,8 @@ class MapPage extends Component {
       mapCenter,
       mapZoom,
       selectedPOI,
-      modal
+      modal,
+      fileList
     } = this.state;
 
     return (
@@ -182,6 +205,7 @@ class MapPage extends Component {
           <MapPOIInfo
             modal={modal}
             poi={selectedPOI}
+            files={fileList}
             toggle={this.handleDeselect}
           />
         )}


### PR DESCRIPTION
closes #104 and closes #103
added
- name and desc for images
- name for audio, can do desc easily if desired

if you look at BJ library images, you'll see that the name and desc are vertically centered for those that arent tall enough... its a problem with the carousel library which ill have to dedicate another session for~
